### PR TITLE
comply with ISO 8601 date standards

### DIFF
--- a/scripts/Taskfile.yml
+++ b/scripts/Taskfile.yml
@@ -795,6 +795,7 @@ tasks:
 
   _clean_turtle_file_from_extra_prefixes:
     desc: Removes additional prefix statements in a Turtle file
+    internal: true
     requires:
       vars: [FILE]
     vars:

--- a/scripts/lib/Preprocessors.py
+++ b/scripts/lib/Preprocessors.py
@@ -77,7 +77,7 @@ class BasePreprocessor(Preprocessor):
                 if value is not None:
                     if int(value):
                         if int(value) < 0:
-                            processedValue = f'-{abs(int(value)):04}'
+                            processedValue = f'-{abs(int(value)):05}'
                         else:
                             processedValue = f'{int(value):04}'
                         datafield.set(f'{self.PREFIX}type', 'gYear')


### PR DESCRIPTION
BCE years need to be at least 5 digits